### PR TITLE
fix: do not offer delete button when looking at other user's drink; i…

### DIFF
--- a/lib/views/drink_details.dart
+++ b/lib/views/drink_details.dart
@@ -39,18 +39,22 @@ class _DrinkDetailsState extends State<DrinkDetails> {
 
     @override
     Widget build(BuildContext context) {
-        return Scaffold(
-            appBar: AppBar(
-                title: Text(widget.drink.name),
-                actions: [
-                    IconButton(
+        var widgets = <Widget>[];
+        var user = Provider.of<UserProvider>(context).user;
+        if (user!.username == widget.drink.username) {
+            widgets.add(IconButton(
                         icon: const Icon(Icons.delete_forever),
                         onPressed: () {
                             confirmDelete(context);
                         }
-                    ),
-                    const Hamburger(),
-                ],),
+                    ));
+        }
+        widgets.add(const Hamburger());
+        return Scaffold(
+            appBar: AppBar(
+                title: Text(widget.drink.name),
+                actions: widgets
+            ),
             body: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 10.0),
                 child: deleteFuture == null ? getMainBody() : loadingSpinner(context),
@@ -169,6 +173,12 @@ class _DrinkDetailsState extends State<DrinkDetails> {
                                 deleteFuture = api.deleteDrink(widget.drink.id);
                                 deleteFuture!.then((_) {
                                     Navigator.of(context).pushNamedAndRemoveUntil(Routes.Dashboard, (route) => false);
+                                }).catchError((e) {
+                                    // first pop clears the confirmation dialog
+                                    Navigator.pop(context);
+                                    // second pop goes back to drinks page
+                                    Navigator.pop(context);
+                                    showErrorSnackbar(context, e.toString());
                                 });
                             });
                         },


### PR DESCRIPTION
…mprove delete error handling
----

Tested the improved error handling by first commenting the new `if` statement to hide the delete button from a non-owner and confirming that we pop the error message, then re-direct back to the main drinks page if you try to delete another user's drink.

With that error handling tested, I then went ahead and just hid the button since you shouldn't really have a delete button when it's not yours anyways.