### PR TITLE
fix: create drink error handling

### DIFF
--- a/lib/add_edit.dart
+++ b/lib/add_edit.dart
@@ -251,7 +251,8 @@ class _AddEditDrinkState extends State<AddEditDrink> {
                 future!.then((val) {
                     Navigator.of(context).pushNamedAndRemoveUntil(Routes.Dashboard, (route) => false);
                 }).catchError((e) {
-                    showErrorSnackbar(context, e);
+                    showErrorSnackbar(context, e.toString());
+                    Navigator.pop(context);
                 });
             });
         }

--- a/lib/api_service.dart
+++ b/lib/api_service.dart
@@ -140,7 +140,7 @@ class ApiService {
         if (resp.statusCode == 200) {
             return Int64(respBody["id"]);
         } else {
-            return respBody["error"];
+            throw Exception(respBody["error"]);
         }
     }
 


### PR DESCRIPTION
currently create drink's error handling doesn't actually work - if there's a non-200 response the app just spins forever

this fixes that