### PR TITLE
fix: populate notes field on add/edit screen

### DIFF
--- a/lib/add_edit.dart
+++ b/lib/add_edit.dart
@@ -53,6 +53,9 @@ class _AddEditDrinkState extends State<AddEditDrink> {
             if (widget.drink!.instructions != null) {
                 instructionsController.text = widget.drink!.instructions!;
             }
+            if (widget.drink!.notes != null) {
+                notesController.text = widget.drink!.notes!;
+            }
             ingredients.addAll(widget.drink!.ingredients);
             for (var i = 0; i < ingredients.length; i++) {
                 ingredientsControllers.add(TextEditingController(text: ingredients[i]));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.3+1
+version: 1.0.4+1
 
 environment:
   sdk: ">=2.16.1 <3.0.0"


### PR DESCRIPTION
previously, the notes field was unset when opening the add/edit screen, meaning your notes would be lost if you ever edited your drink again